### PR TITLE
Fix x265 with -fPIC and enable arm and aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["arm", "aarch64", "x86_64"]
 }
 

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -195,6 +195,16 @@
         {
             "name": "x265",
             "buildsystem": "cmake",
+            "build-options": {
+                "arch": {
+                    "arm": {
+                        "cxxflags": "-fPIC"
+                    },
+                    "aarch64": {
+                        "cxxflags": "-fPIC"
+                    }
+                }
+            },
             "subdir":"source",
             "sources": [
                 {


### PR DESCRIPTION
x265 was failing to compile on aarch64. [Perusal of mailing lists](https://bitbucket.org/multicoreware/x265/issues/91/building-with-fpic) suggests that arm and aarch64 are fixed by passing -fPIC and indeed that works in my test on aarch64. I haven't tested on ARM but it works for Debian, which is usually a pretty good sign.