### PR TITLE
fix gavl on arm

### DIFF
--- a/bad/0002-meson-fix-gl-check.patch
+++ b/bad/0002-meson-fix-gl-check.patch
@@ -1,0 +1,33 @@
+From df0831ce57dc28b8cee9133378fb0f23977fc44c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim-Philipp=20M=C3=BCller?= <tim@centricular.com>
+Date: Tue, 16 Jan 2018 11:25:29 +0000
+Subject: meson: fix check whether both gles2 and opengl headers can be
+ included
+
+cc.compiles() doesn't support the prefix: kwarg currently, so it
+never had any effect.
+
+https://github.com/mesonbuild/meson/issues/2364
+https://bugzilla.gnome.org/show_bug.cgi?id=787964
+---
+ gst-libs/gst/gl/meson.build | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/gl/meson.build b/gst-libs/gst/gl/meson.build
+index 9762a09..68af27f 100644
+--- a/gst-libs/gst/gl/meson.build
++++ b/gst-libs/gst/gl/meson.build
+@@ -366,7 +366,9 @@ endif
+ # can we include both gles2 and opengl headers?
+ if gles2_dep.found() and gl_dep.found()
+   gl_include_block = gl_include_header + gles_includes + opengl_includes
+-  if not cc.compiles('void f (void) {}', prefix : gl_include_block, dependencies : [gles2_dep, gl_dep] )
++  # TODO: Revert to passing gl_include_block via prefix: once
++  # https://github.com/mesonbuild/meson/issues/2364 is fixed
++  if not cc.compiles(gl_include_block + '\n' + 'void f (void) {}',dependencies : [gles2_dep, gl_dep])
+     message ('Cannot include both OpenGL and OpenGL ES headers')
+     if need_gles2 != 'yes'
+       gles2_dep = unneeded_dep
+-- 
+cgit v1.1
+

--- a/bad/0003-meson-fix-gl-variable-names.patch
+++ b/bad/0003-meson-fix-gl-variable-names.patch
@@ -1,0 +1,28 @@
+From 576f4e0c64584da727a66512d0f4512ac894250a Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Mon, 5 Feb 2018 14:56:07 +1100
+Subject: gl/build/meson: fix gl_api variable names
+
+---
+ gst-libs/gst/gl/meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gst-libs/gst/gl/meson.build b/gst-libs/gst/gl/meson.build
+index c6e9e03..18075c1 100644
+--- a/gst-libs/gst/gl/meson.build
++++ b/gst-libs/gst/gl/meson.build
+@@ -370,9 +370,9 @@ if gles2_dep.found() and gl_dep.found()
+   # https://github.com/mesonbuild/meson/issues/2364 is fixed
+   if not cc.compiles(gl_include_block + '\n' + 'void f (void) {}',dependencies : [gles2_dep, gl_dep])
+     message ('Cannot include both OpenGL and OpenGL ES headers')
+-    if need_gles2 != 'yes'
++    if need_api_gles2 != 'yes'
+       gles2_dep = unneeded_dep
+-    elif need_opengl != 'yes'
++    elif need_api_opengl != 'yes'
+       gl_dep = unneeded_dep
+     else
+       error('Both OpenGL and OpenGL ES were requested but cannot be included together')
+-- 
+cgit v1.1
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "only-arches": ["aarch64", "x86_64"]
-}

--- a/gavl/ubuntu_armel_ftbfs.patch
+++ b/gavl/ubuntu_armel_ftbfs.patch
@@ -1,0 +1,18 @@
+Description: Fix build failure on Ubuntu armel.
+Bug-Ubuntu: https://launchpad.net/bugs/704027
+Author: Alessio Treglia <alessio@debian.org>
+---
+ src/Makefile.am |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- gavl.orig/src/Makefile.am
++++ gavl/src/Makefile.am
+@@ -30,7 +30,7 @@ benchmark_LDADD = ../gavl/libgavl.la @RT
+ 
+ 
+ volume_test_SOURCES = volume_test.c
+-volume_test_LDADD = ../gavl/libgavl.la
++volume_test_LDADD = -lm ../gavl/libgavl.la
+ 
+ dump_frame_table_SOURCES = dump_frame_table.c
+ dump_frame_table_LDADD = ../gavl/libgavl.la

--- a/matplotlib/gtk3agg_check_no-multiprocessing.patch
+++ b/matplotlib/gtk3agg_check_no-multiprocessing.patch
@@ -1,0 +1,22 @@
+Author: Julian Taylor <jtaylor.debian@googlemail.com>
+Subject: Avoid using multiprocessing to figure out if Agg backend should be used
+
+   Seems to cause a dead-lock on many Debian systems.
+   We have all necessary dependencies to support Agg so enable the backend
+   unconditionally.
+
+Origin: Ubuntu
+Last-Update: 2014-07-10
+
+--- matplotlib-2/setupext.py.orig	2018-02-08 22:26:23.040580669 +0000
++++ matplotlib-2/setupext.py	2018-02-08 22:27:56.117310250 +0000
+@@ -1718,6 +1718,9 @@
+         if 'TRAVIS' in os.environ:
+             raise CheckFailed("Can't build with Travis")
+ 
++        BackendAgg.force = True
++        return "ok"
++
+         # This check needs to be performed out-of-process, because
+         # importing gi and then importing regular old pygtk afterward
+         # segfaults the interpreter.

--- a/matplotlib/gtk3cairo_check_no-multiprocessing.patch
+++ b/matplotlib/gtk3cairo_check_no-multiprocessing.patch
@@ -1,0 +1,14 @@
+--- a/setupext.py
++++ b/setupext.py
+@@ -1751,7 +1751,10 @@ class BackendGtk3Agg(OptionalBackendPack
+     def check_requirements(self):
+         if 'TRAVIS' in os.environ:
+             raise CheckFailed("Can't build with Travis")
+-
++        # yoh: Builds of Debian packages often lead to a dead-lock here
++        #      As a workaround forcing build manually without a check
++        BackendAgg.force = True
++        return "ok"
+         # This check needs to be performed out-of-process, because
+         # importing gi and then importing regular old pygtk afterward
+         # segfaults the interpreter.

--- a/matplotlib/setup.cfg
+++ b/matplotlib/setup.cfg
@@ -1,0 +1,6 @@
+[gui_support]
+gtk = False
+gtkagg = False
+qt4agg = False
+qt5agg = False
+wxagg = False

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -127,6 +127,18 @@
                     "type": "archive",
                     "url": "https://pypi.python.org/packages/f5/f0/9da3ef24ea7eb0ccd12430a261b66eca36b924aeef06e17147f9f9d7d310/matplotlib-2.0.2.tar.gz",
                     "sha256": "0ffbc44faa34a8b1704bc108c451ecf87988f900ef7ce757b8e2e84383121ff1"
+                },
+                {
+                    "type": "patch",
+                    "path": "matplotlib/gtk3agg_check_no-multiprocessing.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "matplotlib/gtk3cairo_check_no-multiprocessing.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "matplotlib/setup.cfg"
                 }
             ]
         },

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -373,6 +373,14 @@
                 {
                     "type": "patch",
                     "path": "bad/0001-compositor-Add-support-for-crossfade-blending.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "bad/0002-meson-fix-gl-check.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "bad/0003-meson-fix-gl-variable-names.patch"
                 }
             ]
         },

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -335,13 +335,19 @@
         },
         {
             "name": "gavl",
-            "config-opts": ["--without-doxygen"],
             "rm-configure": true,
+            "config-opts": [
+                "--without-doxygen"
+            ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://downloads.sourceforge.net/sourceforge/gmerlin/gavl-1.4.0.tar.gz",
+                    "url": "https://sourceforge.net/projects/gmerlin/files/gavl/1.4.0/gavl-1.4.0.tar.gz",
                     "sha256": "51aaac41391a915bd9bad07710957424b046410a276e7deaff24a870929d33ce"
+                },
+                {
+                    "type": "patch",
+                    "path": "gavl/ubuntu_armel_ftbfs.patch"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
This PR copies a patch from kdeenlive which fixes gavl on arm - and thus enables pitivi on ARM.