### PR TITLE
set up .Codecs extension with H.264, H.265 and AAC

### DIFF
--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -19,8 +19,26 @@
     "build-options": {
         "env": {
           "PYTHON": "python3",
-          "GST_PLUGIN_SYSTEM_PATH": "/app/lib/gstreamer-1.0/",
+          "GST_PLUGIN_SYSTEM_PATH": "/app/lib/gstreamer-1.0/:/app/lib/codecs/lib/gstreamer-1.0/",
           "FREI0R_PATH": "/app/lib/frei0r-1/"
+        },
+        "append-ld-library-path": "/app/lib/codecs/lib",
+        "ldflags": "-L/app/lib/codecs/lib"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/*.a",
+        "/lib/*.la",
+        "/lib/gstreamer-1.0/include",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    "add-extensions": {
+        "org.pitivi.Pitivi.Codecs": {
+            "directory": "lib/codecs",
+            "add-ld-path": "lib",
+            "bundle": true,
+            "autodelete": true
         }
     },
     "modules": [
@@ -150,6 +168,10 @@
                     "url": "http://download.videolan.org/pub/x264/snapshots/x264-snapshot-20140212-2245-stable.tar.bz2",
                     "sha256": "5d98e9e4faf6dd55e7193ed379aff477b8acbda6777758956ef7e5f05067be18"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib",
+                "mv /app/lib/libx264.so* /app/lib/codecs/lib"
             ]
         },
         {
@@ -191,6 +213,10 @@
                     "url": "http://downloads.sourceforge.net/project/opencore-amr/vo-aacenc/vo-aacenc-0.1.3.tar.gz",
                     "sha256": "e51a7477a359f18df7c4f82d195dab4e14e7414cbd48cf79cc195fc446850f36"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib",
+                "mv /app/lib/libvo-aacenc.so* /app/lib/codecs/lib"
             ]
         },
         {
@@ -213,6 +239,10 @@
                     "url": "https://bitbucket.org/multicoreware/x265/downloads/x265_1.9.tar.gz",
                     "sha256": "3e4654133ed957a98708fdb4cb9a154d9e80922b84e26e43fc462a101c5b15c8"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib",
+                "mv /app/lib/libx265.so* /app/lib/codecs/lib"
             ]
         },
         {
@@ -221,6 +251,7 @@
                 "--disable-static",
                 "--disable-avdevice",
                 "--disable-postproc",
+                "--disable-swscale",
                 "--disable-programs",
                 "--disable-ffserver",
                 "--disable-ffplay",
@@ -263,6 +294,10 @@
                     "url": "https://git.ffmpeg.org/ffmpeg.git",
                     "branch": "670d3189e9ef674e4167cec3145ea4c4c172d581"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib",
+                "mv /app/lib/libav*.so* /app/lib/libswresample.so* /app/lib/codecs/lib"
             ]
         },
         {
@@ -275,6 +310,10 @@
                     "branch": "v0.1.5",
                     "commit": "74c1a2a4f831285cbd93ec1427f1670d3c5c5e52"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib",
+                "mv /app/lib/libfdk-aac.so* /app/lib/codecs/lib"
             ]
         },
         {
@@ -331,6 +370,10 @@
                     "url": "git://anongit.freedesktop.org/gstreamer/gst-plugins-ugly",
                     "commit": "46fab99f2ef5581d63c2d11c57fb741553ede37f"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib/gstreamer-1.0",
+                "mv /app/lib/gstreamer-1.0/libgstx264.so /app/lib/codecs/lib/gstreamer-1.0"
             ]
         },
         {
@@ -368,6 +411,10 @@
                     "type": "patch",
                     "path": "bad/0001-compositor-Add-support-for-crossfade-blending.patch"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/lib/codecs/lib/gstreamer-1.0",
+                "mv /app/lib/gstreamer-1.0/libgst{fdkaac,voaacenc,x265}.so /app/lib/codecs/lib/gstreamer-1.0"
             ]
         },
         {


### PR DESCRIPTION
Note that gst-libav is intentionally left in /app/lib/gstreamer-1.0 because
org.freedesktop.Platform{,.ffmpeg} provide successively more capable versions
of libavcodec which provide at least a few decoder formats.

https://github.com/flathub/org.pitivi.Pitivi/issues/6