### PR TITLE
Bump runtime to 3.36

### DIFF
--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.pitivi.Pitivi",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.28",
+    "runtime-version" : "3.36",
     "command" : "pitivi",
     "finish-args" : [
         "--socket=x11",


### PR DESCRIPTION
Pitivi is one of two packages on my machine that depend on 3.28 still. :)
