### PR TITLE
Added Linux Audio plugin support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -15,6 +15,7 @@
         "--env=GST_PLUGIN_PATH=/app/lib/codecs/lib/gstreamer-1.0",
         "--env=GST_ENCODING_TARGET_PATH=/app/share/gstreamer-1.0/encoding-profiles/:/app/share/pitivi/encoding-profiles/",
         "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa",
+        "--env=LV2_PATH=/app/extensions/Plugins/lv2",
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=host",
         "--device=dri"
@@ -49,7 +50,7 @@
             "directory": "extensions/Plugins",
             "version": "19.08",
             "add-ld-path": "lib",
-            "merge-dirs": "ladspa",
+            "merge-dirs": "ladspa;lv2",
             "subdirectories": true,
             "no-autodownload": true
         }
@@ -392,6 +393,8 @@
                 "mv /app/lib/gstreamer-1.0/libgstx264.so /app/lib/codecs/lib/gstreamer-1.0"
             ]
         },
+        "shared-modules/linux-audio/lv2.json",
+        "shared-modules/linux-audio/lilv.json",
         {
             "name" : "gst-plugins-bad",
             "buildsystem" : "meson",

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -14,6 +14,7 @@
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=GST_PLUGIN_PATH=/app/lib/codecs/lib/gstreamer-1.0",
         "--env=GST_ENCODING_TARGET_PATH=/app/share/gstreamer-1.0/encoding-profiles/:/app/share/pitivi/encoding-profiles/",
+        "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa",
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=host",
         "--device=dri"
@@ -43,6 +44,14 @@
             "add-ld-path" : "lib",
             "bundle" : true,
             "autodelete" : true
+        },
+        "org.freedesktop.LinuxAudio.Plugins": {
+            "directory": "extensions/Plugins",
+            "version": "19.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "ladspa",
+            "subdirectories": true,
+            "no-autodownload": true
         }
     },
     "modules" : [
@@ -508,6 +517,9 @@
             "name" : "pitivi",
             "buildsystem" : "meson",
             "builddir" : true,
+            "post-install": [
+                "install -d /app/extensions/Plugins"
+            ],
             "sources" : [
                 {
                     "type" : "git",


### PR DESCRIPTION
~~The LV2 support in gstreamer isn't available. I'll see if I can add it later.~~ it was easier than I thought: I just added lilv from the `shared-modules` to the manifest (and then the path).

This allow LADSPA plugins that can be installed through flatpak.

(SWH, CMT, CAPS, TAP, LSP, etc)