### PR TITLE
Use fallback-x11 instead of x11 permission

### DIFF
--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -4,7 +4,7 @@
     "runtime-version": "3.38",
     "command": "pitivi",
     "finish-args": [
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--share=ipc",
         "--socket=pulseaudio",
         "--socket=wayland",


### PR DESCRIPTION
For GTK apps this is a safe operation, unless the app directly interacts with x11.