### PR TITLE
Update runtime to GNOME 50

### DIFF
--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -437,7 +437,8 @@
                     "type": "patch",
                     "paths": [
 			"patches/pitivi-appdata.patch",
-			"patches/pitivi-viewer.patch"
+			"patches/pitivi-viewer.patch",
+			"patches/pitivi-thumbnails.patch"
 		    ]
                 }
             ]

--- a/org.pitivi.Pitivi.json
+++ b/org.pitivi.Pitivi.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.pitivi.Pitivi",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "pitivi",
     "rename-mime-icons": [
@@ -49,7 +49,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "24.08",
+            "version": "25.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa;lv2",
             "subdirectories": true,
@@ -60,6 +60,9 @@
         {
             "name": "openblas",
             "no-autogen": true,
+            "build-options": {
+                "cflags": "-std=gnu18"
+            },
             "make-args": [
                 "DYNAMIC_ARCH=1",
                 "FC=gfortran",
@@ -81,6 +84,7 @@
         "python3-meson-python.json",
         "python3-scipy.json",
         "python3-cppy.json",
+        "python3-six.json",
         "python3-matplotlib.json",
         {
             "name": "lapack",
@@ -91,6 +95,7 @@
             ],
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
                 "-DBUILD_SHARED_LIBS=ON",
                 "-DBUILD_TESTING=OFF",
                 "-DLAPACKE=ON",
@@ -99,11 +104,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.11.tar.gz",
-                    "sha256": "5a5b3bac27709d8c66286b7a0d1d7bf2d7170ec189a1a756fdf812c97aa7fd10"
+                    "url": "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz",
+                    "sha256": "2ca6407a001a474d4d4d35f3a61550156050c48016d949f0da0529c0aa052422"
                 }
             ]
         },
+        "python3-scikit-build-core.json",
+        "python3-setuptools_scm.json",
+        "python3-nanobind.json",
         "python3-librosa.json",
         "shared-modules/libcanberra/libcanberra.json",
         {
@@ -177,6 +185,9 @@
         {
             "name": "frei0r-plugin",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -216,6 +227,9 @@
         {
             "name": "x265",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+            ],
             "build-options": {
                 "arch": {
                     "aarch64": {
@@ -229,66 +243,10 @@
                     "type": "archive",
                     "url": "https://get.videolan.org/x265/x265_3.2.1.tar.gz",
                     "sha256": "fb9badcf92364fd3567f8b5aa0e5e952aeea7a39a2b864387cec31e3b58cbbcc"
-                }
-            ]
-        },
-        {
-            "name": "ffmpeg",
-            "build-options": {
-                "cflags": "-fpermissive"
-            },
-            "config-opts": [
-                "--disable-static",
-                "--enable-shared",
-                "--enable-pic",
-                "--disable-avdevice",
-                "--disable-postproc",
-                "--disable-swscale",
-                "--disable-programs",
-                "--disable-ffplay",
-                "--disable-ffprobe",
-                "--disable-ffmpeg",
-                "--disable-encoder=flac",
-                "--disable-protocols",
-                "--disable-devices",
-                "--disable-network",
-                "--disable-hwaccels",
-                "--disable-dxva2",
-                "--disable-vdpau",
-                "--disable-filters",
-                "--enable-filter=yadif",
-                "--disable-doc",
-                "--disable-d3d11va",
-                "--disable-dxva2",
-                "--disable-audiotoolbox",
-                "--disable-videotoolbox",
-                "--disable-vaapi",
-                "--disable-crystalhd",
-                "--disable-mediacodec",
-                "--disable-nvenc",
-                "--disable-mmal",
-                "--disable-omx",
-                "--disable-omx-rpi",
-                "--disable-cuda",
-                "--disable-cuvid",
-                "--disable-libmfx",
-                "--disable-libnpp",
-                "--disable-iconv",
-                "--disable-jni",
-                "--disable-v4l2_m2m",
-                "--enable-gpl",
-                "--enable-optimizations"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/FFmpeg/FFmpeg.git",
-                    "tag": "n4.1.11",
-                    "commit": "76ee3e41df5157317ee209d3e6cc0829af5f963f"
                 },
                 {
                     "type": "patch",
-                    "path": "patches/ffmpeg-as-fix.patch"
+                    "path": "patches/x265-cmake.patch"
                 }
             ]
         },
@@ -388,6 +346,10 @@
                     "url": "https://github.com/opencv/opencv_contrib/archive/4.8.0.tar.gz",
                     "sha256": "b4aef0f25a22edcd7305df830fa926ca304ea9db65de6ccd02f6cfa5f3357dbb",
                     "dest": "contrib"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/opencv-cmake.patch"
                 }
             ]
         },
@@ -399,7 +361,6 @@
             "buildsystem": "meson",
             "builddir": true,
             "config-opts": [
-                "--libdir=lib",
                 "-Dgpl=enabled",
                 "-Dbad=enabled",
                 "-Dugly=enabled",
@@ -413,28 +374,27 @@
                 "mv /app/lib/libx265.so* /app/lib/codecs/lib",
                 "mv /app/lib/libfdk-aac.so* /app/lib/codecs/lib",
                 "mv /app/lib/gstreamer-1.0/libgst{fdkaac,voaacenc,x265}.so /app/lib/codecs/lib/gstreamer-1.0",
-                "mkdir -p /app/lib/codecs/lib",
-                "mv /app/lib/libav*.so* /app/lib/libswresample.so* /app/lib/codecs/lib",
                 "mv /app/lib/gstreamer-1.0/libgstlibav.so /app/lib/codecs/lib/gstreamer-1.0"
             ],
             "sources": [
                 {
                     "type": "git",
-                    "tag": "1.22.10",
+                    "tag": "1.26.8",
                     "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-                    "commit": "29d6413c3f4ed9656ba161ef500823c47eb59004"
+                    "commit": "16d77e12ad213ef24e76a8cc34d347b8221c9975"
                 },
                 {
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/gstreamer/orc.git",
-                    "commit": "7d5bbada3f1c6cf34182abccf47a34d79b83fa97",
-                    "tag": "0.4.34",
+                    "commit": "96dfe82ae431d8e4e06b6092171e231d693a73b5",
+                    "tag": "0.4.41",
                     "dest": "subprojects/orc"
                 }
             ]
         },
         {
             "name": "pygobject",
+            "//": "This is necessary because the version in the runtime no longer support the libpeas that is needed for pitivi",
             "buildsystem": "meson",
             "config-opts": [
                 "-Dtests=false"
@@ -475,7 +435,10 @@
                 },
                 {
                     "type": "patch",
-                    "path": "patches/pitivi-appdata.patch"
+                    "paths": [
+			"patches/pitivi-appdata.patch",
+			"patches/pitivi-viewer.patch"
+		    ]
                 }
             ]
         }

--- a/patches/opencv-cmake.patch
+++ b/patches/opencv-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/OpenCVGenPkgconfig.cmake b/cmake/OpenCVGenPkgconfig.cmake
+index 43d6a87..7eba012 100644
+--- a/cmake/OpenCVGenPkgconfig.cmake
++++ b/cmake/OpenCVGenPkgconfig.cmake
+@@ -94,7 +94,7 @@ file(GENERATE OUTPUT "${CMAKE_HELPER_SCRIPT}" CONTENT "${HELPER_SCRIPT}")
+ add_custom_target(developer_scripts)
+ add_custom_command(
+   OUTPUT "${CMAKE_BINARY_DIR}/unix-install/${OPENCV_PC_FILE_NAME}"
+-  COMMAND ${CMAKE_COMMAND} "-DCMAKE_HELPER_SCRIPT=${CMAKE_HELPER_SCRIPT}" -P "${OpenCV_SOURCE_DIR}/cmake/OpenCVGenPkgconfig.cmake"
++  COMMAND ${CMAKE_COMMAND} "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" "-DCMAKE_HELPER_SCRIPT=${CMAKE_HELPER_SCRIPT}" -P "${OpenCV_SOURCE_DIR}/cmake/OpenCVGenPkgconfig.cmake"
+   DEPENDS "${CMAKE_BINARY_DIR}/OpenCVGenPkgConfig.info.cmake"
+           "${OpenCV_SOURCE_DIR}/cmake/OpenCVGenPkgconfig.cmake"
+   COMMENT "Generate ${OPENCV_PC_FILE_NAME}"

--- a/patches/pitivi-appdata.patch
+++ b/patches/pitivi-appdata.patch
@@ -1,8 +1,16 @@
 diff --git a/data/org.pitivi.Pitivi.appdata.xml.in b/data/org.pitivi.Pitivi.appdata.xml.in
-index eb2fb10..33ad0f4 100644
+index eb2fb10..9dc3df1 100644
 --- a/data/org.pitivi.Pitivi.appdata.xml.in
 +++ b/data/org.pitivi.Pitivi.appdata.xml.in
-@@ -36,7 +36,6 @@
+@@ -22,6 +22,7 @@
+   <screenshots>
+     <screenshot type="default">
+       <image>https://www.pitivi.org/i/screenshots/2020.05.png</image>
++      <caption>Main Window</caption>
+     </screenshot>
+   </screenshots>
+   <url type="homepage">https://www.pitivi.org</url>
+@@ -36,7 +37,6 @@
      <kudo>Notifications</kudo>
    </kudos>
    <update_contact>pitivi@pitivi.org</update_contact>
@@ -10,3 +18,15 @@ index eb2fb10..33ad0f4 100644
    <translation type="gettext">pitivi</translation>
    <developer_name>The Pitivi Team</developer_name>
  
+@@ -357,10 +357,7 @@
+         </ul>
+       </description>
+     </release>
+-    <release version="0.15.2" date="2012-05-3">
+-      <description>
+-      </description>
+-    </release>
++    <release version="0.15.2" date="2012-05-3" />
+     <release version="0.15.1" date="2012-02-24">
+       <description>
+         <p>This release adds the following features:</p>

--- a/patches/pitivi-thumbnails.patch
+++ b/patches/pitivi-thumbnails.patch
@@ -1,0 +1,34 @@
+commit 57199472dd42d96b2b31eea5c457deaabd38a07d
+Author: Hubert Figuière <hub@figuiere.net>
+Date:   Sat Mar 28 17:20:50 2026 -0400
+
+    timeline: generate thumbnails in RGB
+    
+    RGBA isn't supported to be saved as JPEG.
+    
+    See https://gitlab.gnome.org/GNOME/pitivi/-/issues/2677
+    
+    Signed-off-by: Hubert Figuière <hub@figuiere.net>
+
+diff --git a/pitivi/timeline/previewers.py b/pitivi/timeline/previewers.py
+index d299857b..042f399e 100644
+--- a/pitivi/timeline/previewers.py
++++ b/pitivi/timeline/previewers.py
+@@ -118,7 +118,7 @@ class TeedThumbnailBin(PreviewerBin):
+     def __init__(self, bin_desc="videoconvert ! videoflip method=automatic ! tee name=t ! queue  "
+                  "max-size-buffers=0 max-size-bytes=0 max-size-time=0  ! "
+                  "videoconvert ! videorate ! videoscale method=lanczos ! "
+-                 "capsfilter caps=video/x-raw,format=(string)RGBA,height=(int)%d,"
++                 "capsfilter caps=video/x-raw,format=(string)RGB,height=(int)%d,"
+                  "pixel-aspect-ratio=(fraction)1/1,"
+                  "framerate=2/1 ! gdkpixbufsink name=gdkpixbufsink "
+                  "t. ! queue " % THUMB_HEIGHT):
+@@ -630,7 +630,7 @@ class AssetPreviewer(Previewer, Loggable):
+             "videorate ! "
+             "videoflip method=automatic ! "
+             "videoscale method=lanczos ! "
+-            "capsfilter caps=video/x-raw,format=(string)RGBA,height=(int){height},"
++            "capsfilter caps=video/x-raw,format=(string)RGB,height=(int){height},"
+             "pixel-aspect-ratio=(fraction)1/1,framerate={thumbs_per_second}/1 ! "
+             "gdkpixbufsink name=gdkpixbufsink".format(
+                 uri=self.uri,

--- a/patches/pitivi-viewer.patch
+++ b/patches/pitivi-viewer.patch
@@ -1,0 +1,58 @@
+From 52cb30ae78e8322fc4055b1f064ec86427fd5a9c Mon Sep 17 00:00:00 2001
+From: Thibault Saunier <tsaunier@igalia.com>
+Date: Mon, 3 Mar 2025 09:03:41 -0300
+Subject: [PATCH] viewer: Fix a race where gtksink is started before being
+ embedded in the UI
+
+Which was leading to g_warning and an external Gtk window to pop up.
+
+We now set the preview video sink only once it has already
+been embedded in our widget avoiding that possible issue
+---
+ pitivi/utils/pipeline.py | 4 ----
+ pitivi/viewer/viewer.py  | 4 +++-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/pitivi/utils/pipeline.py b/pitivi/utils/pipeline.py
+index d85055665..39fa9b4cf 100644
+--- a/pitivi/utils/pipeline.py
++++ b/pitivi/utils/pipeline.py
+@@ -563,10 +563,6 @@ class Pipeline(GES.Pipeline, SimplePipeline):
+                 watchdog.props.timeout = WATCHDOG_TIMEOUT * 1000
+                 self.props.audio_filter = watchdog
+ 
+-    def create_sink(self):
+-        video_sink, sink_widget = SimplePipeline.create_sink(self)
+-        self._pipeline.preview_set_video_sink(video_sink)
+-        return video_sink, sink_widget
+ 
+     def set_mode(self, mode):
+         self._next_seek = None
+diff --git a/pitivi/viewer/viewer.py b/pitivi/viewer/viewer.py
+index 0ea7a183e..010ad1693 100644
+--- a/pitivi/viewer/viewer.py
++++ b/pitivi/viewer/viewer.py
+@@ -175,10 +175,10 @@ class ViewerContainer(Gtk.Box, Loggable):
+         project.connect("audio-channels-changed", self._project_audio_channels_changed_cb)
+ 
+     def __create_new_viewer(self):
+-        _, sink_widget = self.project.pipeline.create_sink()
+ 
+         self.guidelines_popover = GuidelinesPopover()
+         self.guidelines_button.set_popover(self.guidelines_popover)
++        video_sink, sink_widget = self.project.pipeline.create_sink()
+         self.overlay_stack = OverlayStack(self.app,
+                                           sink_widget,
+                                           self.guidelines_popover.overlay)
+@@ -194,6 +194,8 @@ class ViewerContainer(Gtk.Box, Loggable):
+ 
+         self.viewer_row_box.show_all()
+ 
++        self.project.pipeline.preview_set_video_sink(video_sink)
++
+         # Wait for 1s to make sure that the viewer has completely realized
+         # and then we can mark the resize status as showable.
+         GLib.timeout_add(1000, self.__viewer_realization_done_cb, None)
+-- 
+GitLab
+

--- a/patches/x265-cmake.patch
+++ b/patches/x265-cmake.patch
@@ -1,0 +1,20 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 1d1a613..c60431b 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -7,13 +7,13 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+ if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
++    cmake_policy(SET CMP0025 NEW) # report Apple's Clang as just Clang
+ endif()
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+ if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
++    cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted
+ endif()
+ 
+ project (x265)

--- a/python3-librosa.json
+++ b/python3-librosa.json
@@ -27,28 +27,14 @@
                 },
 		{
 		    "type": "file",
-                    "only-arches": [ "x86_64" ],
-		    "url": "https://files.pythonhosted.org/packages/04/2a/c833a8503be9030083f0469e7a3c74d3622a3b4eae676c3934d3ccc01036/msgpack-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-		    "sha256": "8db8e423192303ed77cff4dce3a4b88dbfaf43979d280181558af5e2c3c71afc"
-		},
-		{
-		    "type": "file",
-                    "only-arches": [ "aarch64" ],
-		    "url": "https://files.pythonhosted.org/packages/54/f7/84828d0c6be6b7f0770777f1a7b1f76f3a78e8b6afb5e4e9c1c9350242be/msgpack-1.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-		    "sha256": "0726c282d188e204281ebd8de31724b7d749adebc086873a59efb8cf7ae27df3"
-		},
-		{
-		    "type": "file",
-                    "only-arches": [ "x86_64" ],
-		    "url": "https://files.pythonhosted.org/packages/1b/51/54a6bbb3c0e80b7f59a7e30a4643fef18f43b75ce30512a6baf4afb8d490/soxr-0.3.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-		    "sha256": "ea663b76f2b0ec1576b8a43aef317aec080abc0a67a4015fcd9f3407039f260a"
-		},
-		{
-		    "type": "file",
-                    "only-arches": [ "aarch64" ],
-		    "url": "https://files.pythonhosted.org/packages/7a/1a/1287a8d6a470d1ce5084269ec7ac17dfc8eeb3e48bec3bd0be0eefed8ed4/soxr-0.3.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-		    "sha256": "48acdfbcf870ab54f645b1cfd641bce92c1e3a67346c3bf0f6c0ad2873c1dd35"
-		},
+		    "url": "https://files.pythonhosted.org/packages/08/4c/17adf86a8fbb02c144c7569dc4919483c01a2ac270307e2d59e1ce394087/msgpack-1.0.8.tar.gz",
+		    "sha256": "95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fa/9c/e97a426803b2a3666078683f7f50088c34fba950ad74bde365b1b5545919/soxr-0.5.0.tar.gz",
+                    "sha256": "6db338bbb01b73ad31534dd48e1b1eafa767714223f7d403c7633c987bdbd719"
+                },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ec/03/062e6444ce4baf1eac17a6a0ebfe36bb1ad05e1df0e20b110de59c278498/urllib3-1.26.9-py2.py3-none-any.whl",
@@ -87,19 +73,19 @@
                 {
                     "type": "file",
                     "only-arches": [ "x86_64" ],
-                    "url": "https://files.pythonhosted.org/packages/62/af/c3df8a3f26c3cff7730ab1cb7c7a4c899f8c4fb4acd9020150d1599575ac/llvmlite-0.42.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                    "sha256": "d47494552559e00d81bfb836cf1c4d5a5062e54102cc5767d5aa1e77ccd2505c"
+                    "url": "https://files.pythonhosted.org/packages/d2/1b/656f5a357de7135a3777bd735cc7c9b8f23b4d37465505bd0eaf4be9befe/llvmlite-0.44.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "46224058b13c96af1365290bdfebe9a6264ae62fb79b2b55693deed11657a8bf"
                 },
                 {
                     "type": "file",
                     "only-arches": [ "aarch64" ],
-                    "url": "https://files.pythonhosted.org/packages/9a/c5/7a1716343ad90204fde896bc052707bc6946cc32a52616d141e494d518a3/llvmlite-0.42.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-                    "sha256": "ebe66a86dc44634b59a3bc860c7b20d26d9aaffcd30364ebe8ba79161a9121f4"
+                    "url": "https://files.pythonhosted.org/packages/d8/e1/12c5f20cb9168fb3464a34310411d5ad86e4163c8ff2d14a2b57e5cc6bac/llvmlite-0.44.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "aa0097052c32bf721a4efc03bd109d335dfa57d9bffb3d4c24cc680711b8b4fc"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz",
-                    "sha256": "920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"
+                    "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+                    "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
                 },
                 {
                     "type": "file",
@@ -114,14 +100,14 @@
                 {
                     "type": "file",
                     "only-arches": [ "x86_64" ],
-                    "url": "https://files.pythonhosted.org/packages/5d/b7/ee35904c07a0666784349529412fbb9814a56382b650d30fd9d6be5e5054/scikit_learn-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                    "sha256": "5b2de18d86f630d68fe1f87af690d451388bb186480afc719e5f770590c2ef6c"
+                    "url": "https://files.pythonhosted.org/packages/a7/48/fbfb4dc72bed0fe31fe045fb30e924909ad03f717c36694351612973b1a9/scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "f7284ade780084d94505632241bf78c44ab3b6f1e8ccab3d2af58e0e950f9c12"
                 },
                 {
                     "type": "file",
                     "only-arches": [ "aarch64" ],
-                    "url": "https://files.pythonhosted.org/packages/e5/a7/6f4ae76f72ae9de162b97acbf1f53acbe404c555f968d13da21e4112a002/scikit_learn-1.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-                    "sha256": "cb06f8dce3f5ddc5dee1715a9b9f19f20d295bed8e3cd4fa51e1d050347de525"
+                    "url": "https://files.pythonhosted.org/packages/b1/c8/f08313f9e2e656bd0905930ae8bf99a573ea21c34666a813b749c338202f/scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "178ddd0a5cb0044464fc1bfc4cca5b1833bfc7bb022d70b05db8530da4bb3dd3"
                 },
                 {
                     "type": "file",
@@ -140,13 +126,13 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/bb/84/468592513867604800592b58d106f5e7e6ef61de226b59c1e9313917fbbb/numba-0.59.1.tar.gz",
-                    "sha256": "76f69132b96028d2774ed20415e8c528a34e3299a40581bae178f0994a2f370b"
+                    "url": "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz",
+                    "sha256": "8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/7c/91/d3ba0401e62d7e42816bc7d97b82d19c95c164b3e149a87c0a1c026a735e/joblib-1.1.1-py2.py3-none-any.whl",
-                    "sha256": "f9d6c3cdf2a7778e9058e10e9dba028e47771a1a355e5768f46704bf05342eba"
+                    "url": "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl",
+                    "sha256": "5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"
                 },
                 {
                     "type": "file",
@@ -157,6 +143,26 @@
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/57/8d/30aa32745af16af0a9a650115fbe81bde7c610ed5c21b381fca0196f3a7f/audioread-3.0.1-py3-none-any.whl",
                     "sha256": "4cdce70b8adc0da0a3c9e0d85fb10b3ace30fbdf8d1670fd443929b61d117c33"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c3/52/5fbb203394cc852334d1575cc020f6bcec768d2265355984dfd361968f36/standard_aifc-3.13.0-py3-none-any.whl",
+                    "sha256": "f7ae09cc57de1224a0dd8e3eb8f73830be7c3d0bc485de4c1f82b4a7f645ac66"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7a/90/a5c1084d87767d787a6caba615aa50dc587229646308d9420c960cb5e4c0/standard_chunk-3.13.0-py3-none-any.whl",
+                    "sha256": "17880a26c285189c644bd5bd8f8ed2bdb795d216e3293e6dbe55bbd848e2982c"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/34/ae/e3707f6c1bc6f7aa0df600ba8075bfb8a19252140cd595335be60e25f9ee/standard_sunau-3.13.0-py3-none-any.whl",
+                    "sha256": "53af624a9529c41062f4c2fd33837f297f3baa196b0cfceffea6555654602622"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz",
+                    "sha256": "64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0"
                 },
                 {
                     "type": "file",

--- a/python3-matplotlib.json
+++ b/python3-matplotlib.json
@@ -22,35 +22,35 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/bc/b3/9458adb9472e61a998c8c4d95cfdfec91c73c53a375b30b1428310f923e4/kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "sha256": "cc978a80a0db3a66d25767b03688f1147a69e6237175c0f4ffffaaedf744055a",
-	    "only-arches": [
-		"x86_64"
-	    ]
+            "url": "https://files.pythonhosted.org/packages/e9/e9/f218a2cb3a9ffbe324ca29a9e399fa2d2866d7f348ec3a88df87fc248fc5/kiwisolver-1.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "b67e6efbf68e077dd71d1a6b37e43e1a99d0bff1a3d51867d45ee8908b931098",
+            "only-arches": [
+                "x86_64"
+            ]
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/29/61/39d30b99954e6b46f760e6289c12fede2ab96a254c443639052d1b573fbc/kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "sha256": "257af1622860e51b1a9d0ce387bf5c2c4f36a90594cb9514f55b074bcc787cfc",
-	    "only-arches": [
-		"aarch64"
-	    ]
+            "url": "https://files.pythonhosted.org/packages/d9/28/aac26d4c882f14de59041636292bc838db8961373825df23b8eeb807e198/kiwisolver-1.4.9-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl",
+            "sha256": "5656aa670507437af0207645273ccdfee4f14bacd7f7c67a4306d0dcaeaf6eed",
+            "only-arches": [
+                "aarch64"
+            ]
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/cd/ba/412149958e951876096198609b958b90a8a2c9bc07a96eeeaa9e2c480f30/matplotlib-3.8.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "sha256": "f51c4c869d4b60d769f7b4406eec39596648d9d70246428745a681c327a8ad30",
-	    "only-arches": [
-		"x86_64"
-	    ]
+            "url": "https://files.pythonhosted.org/packages/f8/6b/9eb761c00e1cb838f6c92e5f25dcda3f56a87a52f6cb8fdfa561e6cf6a13/matplotlib-3.9.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "sha256": "2b8c97917f21b75e72108b97707ba3d48f171541a74aa2a56df7a40626bafc64",
+            "only-arches": [
+                "x86_64"
+            ]
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/61/cd/976d3a9c10328da1d2fe183f7c92c45f1e125536226a6eb3a820c4753cd1/matplotlib-3.8.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "sha256": "50bac6e4d77e4262c4340d7a985c30912054745ec99756ce213bfbc3cb3808eb",
-	    "only-arches": [
-		"aarch64"
-	    ]
+            "url": "https://files.pythonhosted.org/packages/65/87/ac498451aff739e515891bbb92e566f3c7ef31891aaa878402a71f9b0910/matplotlib-3.9.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+            "sha256": "f4c12302c34afa0cf061bea23b331e747e5e554b0fa595c96e01c7b75bc3b858",
+            "only-arches": [
+                "aarch64"
+            ]
         },
         {
             "type": "file",

--- a/python3-nanobind.json
+++ b/python3-nanobind.json
@@ -1,0 +1,17 @@
+{
+    "name": "python3-nanobind",
+    "buildsystem": "simple",
+    "cleanup": [
+	"*"
+    ],
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"nanobind\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/14/06/cb08965f985a5e1b9cb55ed96337c1f6daaa6b9cbdaeabe6bb3f7a1a11df/nanobind-2.10.2-py3-none-any.whl",
+            "sha256": "6976c1b04b90481d2612b346485a3063818c6faa5077fe9d8bbc9b5fbe29c380"
+        }
+    ]
+}

--- a/python3-scikit-build-core.json
+++ b/python3-scikit-build-core.json
@@ -1,0 +1,22 @@
+{
+    "name": "python3-scikit-build-core",
+    "buildsystem": "simple",
+    "cleanup": [
+	"*"
+    ],
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scikit-build-core\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl",
+            "sha256": "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/43/49/ec16b3db6893db788ae35f98506ff5a9c25dca7eb18cc38ada8a4c1dc944/scikit_build_core-0.11.6-py3-none-any.whl",
+            "sha256": "ce6d8fe64e6b4c759ea0fb95d2f8a68f60d2df31c2989838633b8ec930736360"
+        }
+    ]
+}

--- a/python3-scipy.json
+++ b/python3-scipy.json
@@ -79,8 +79,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/30/85/cdbf2c3c460fe5aae812917866392068a88d02f07de0fe31ce738734c477/scipy-1.12.0.tar.gz",
-                    "sha256": "4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3"
+                    "url": "https://files.pythonhosted.org/packages/62/11/4d44a1f274e002784e4dbdb81e0ea96d2de2d1045b2132d5af62cc31fd28/scipy-1.14.1.tar.gz",
+                    "sha256": "5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417"
                 }
             ]
         }

--- a/python3-setuptools_scm.json
+++ b/python3-setuptools_scm.json
@@ -1,0 +1,17 @@
+{
+    "name": "python3-setuptools_scm",
+    "buildsystem": "simple",
+    "cleanup": [
+	"*"
+    ],
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools_scm\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl",
+            "sha256": "30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7"
+        }
+    ]
+}

--- a/python3-six.json
+++ b/python3-six.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-six",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"six\" --no-build-isolation"
+    ],
+    "sources": [
+	{
+	    "type": "file",
+	    "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz",
+	    "sha256": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+	}
+    ]
+}


### PR DESCRIPTION
- Added patches to build x265, opencv
- Removed ffmpeg: it's in the runtime and gstreamer didn't like the old version being build.
- Update python package for python 3.13
- Added python build deps nanobind, scikit-build-core, setuptools_scm
- Added six that is no longer in the runtime.



Not completely sure of the regressions:

I get this on the console:
```
(pitivi:2): Gtk-WARNING **: 12:47:49.641: Attempting to add a widget with type GtkGstWidget to a container of type pitivi+viewer+overlay_stack+OverlayStack, but the widget is already inside a container of type GtkWindow, please remove the widget from its existing container first.
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
Traceback (most recent call last):
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 767, in __bus_message_cb
    self.thumb_cache[self.position] = pixbuf
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/lib/pitivi/python/pitivi/timeline/previewers.py", line 1095, in __setitem__
    success, jpeg = pixbuf.save_to_bufferv(
                    ~~~~~~~~~~~~~~~~~~~~~~^
        "jpeg", ["quality", None], ["90"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8` (0)
ERROR 12:47:56 pipeline          pitivi+utils+pipeline+pipeline0 _handle_error_message: error from <__gi__.GstGtkSink object at 0x7fcdd2eff800 (GstGtkSink at 0x55591a758430)>: gst-resource-error-quark: Output widget was destroyed (3) (../subprojects/gst-plugins-good/ext/gtk/gstgtkbasesink.c(562): gst_gtk_base_sink_show_frame (): /pitivi+utils+pipeline+Pipeline:pitivi+utils+pipeline+pipeline0/GstPlaySink:internal-sinks/GstBin:vbin/GstGtkSink:gtksink0) (../../../../../../app/lib/pitivi/python/pitivi/utils/pipeline.py:489)
ERROR 12:47:56 pipeline          pitivi+utils+pipeline+pipeline0 _recover: Resetting pipeline because error detected during playback. Try 1 (../../../../../../app/lib/pitivi/python/pitivi/utils/pipeline.py:475)

(pitivi:2): Gtk-WARNING **: 12:51:53.479: Attempting to add a widget with type GtkGstWidget to a container of type pitivi+viewer+overlay_stack+OverlayStack, but the widget is already inside a container of type GtkWindow, please remove the widget from its existing container first.

(pitivi:2): Gtk-WARNING **: 12:52:00.343: Attempting to add a widget with type GtkGstWidget to a container of type pitivi+viewer+overlay_stack+OverlayStack, but the widget is already inside a container of type GtkWindow, please remove the widget from its existing container first.
```

One of the thing is the video is played in a separate window. As for the other errors it seems to be related to glycin that replace the gdkpixbuf loaders.